### PR TITLE
feat: add weather-based heating/cooling control

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -51,6 +51,8 @@ jobs:
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           install-command: "npm install"
           build: true
+          # Run unit tests
+          extra-tests: "npm run test:ts"
   # Deploys the final package to NPM
   deploy:
     needs: [check-and-lint, adapter-tests]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This adapter provides comprehensive heating system management for ioBroker insta
 ## Features
 
 - **Dual Mode Support**: Switch between heating and cooling modes
+- **Weather-based Control**: Automatically activate/deactivate based on outside temperature
 - **Boost Mode**: Temporarily increase heating/cooling for individual rooms
 - **Pause Mode**: Temporarily disable heating/cooling for specific rooms
 - **Time-based Scheduling**: Define temperature periods for different times and days
@@ -89,6 +90,21 @@ Configure temperature schedules for each room:
 - **Boost Duration**: Auto-reset time for boost mode (minutes)
 - **Humidity Threshold**: Maximum humidity before cooling stops
 - **Reset on Startup**: Overwrite all temperatures with default values on adapter start
+
+#### Weather-based Control (Optional)
+
+Enable intelligent operation based on outside temperature:
+
+- **Enable Weather Control**: Activate weather-based heating/cooling control
+- **Weather Data Source**: Select the state containing outside temperature data
+- **Heating Threshold**: Only activate heating if outside temperature is below this value (default: 15°C)
+- **Cooling Threshold**: Only activate cooling if outside temperature is above this value (default: 24°C)
+
+**How it works:**
+- In heating mode: System only operates when outside temperature < threshold
+- In cooling mode: System only operates when outside temperature > threshold
+- Takes priority over all other settings (periods, boost, absence)
+- If weather data is unavailable, system operates normally as fallback
 
 ## Usage
 
@@ -197,6 +213,13 @@ Enable debug logging in adapter settings to see detailed information about:
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+
+### **WORK IN PROGRESS**
+
+- (jbeenenga) add weather-based heating/cooling control
+- (jbeenenga) refactor business logic into service classes
+- (jbeenenga) add comprehensive unit tests
+- (jbeenenga) update dependencies to latest versions
 
 ### 2.0.3 (2025-07-02)
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -20,6 +20,7 @@ Dieser Adapter bietet eine umfassende Heizungssteuerung für ioBroker-Installati
 ## Funktionen
 
 - **Dual-Modus-Unterstützung**: Wechseln zwischen Heiz- und Kühlmodus
+- **Wetterbasierte Steuerung**: Automatische Aktivierung/Deaktivierung basierend auf Außentemperatur
 - **Boost-Modus**: Temporäre Erhöhung der Heizung/Kühlung für einzelne Räume
 - **Pause-Modus**: Temporäre Deaktivierung der Heizung/Kühlung für bestimmte Räume
 - **Zeitbasierte Planung**: Definition von Temperaturperioden für verschiedene Zeiten und Tage
@@ -81,6 +82,21 @@ Konfigurieren Sie Temperaturpläne für jeden Raum:
 - **Boost-Dauer**: Auto-Reset-Zeit für Boost-Modus (Minuten)
 - **Feuchtigkeitsschwellenwert**: Maximale Feuchtigkeit bevor Kühlung stoppt
 - **Reset beim Start**: Überschreibt alle Temperaturen mit Standardwerten beim Adapter-Start
+
+#### Wetterbasierte Steuerung (Optional)
+
+Intelligenter Betrieb basierend auf der Außentemperatur:
+
+- **Wettersteuerung aktivieren**: Wetterbasierte Heiz-/Kühlsteuerung aktivieren
+- **Wetterdatenquelle**: State mit Außentemperaturdaten auswählen
+- **Heizschwellenwert**: Heizung nur aktivieren wenn Außentemperatur unter diesem Wert liegt (Standard: 15°C)
+- **Kühlschwellenwert**: Kühlung nur aktivieren wenn Außentemperatur über diesem Wert liegt (Standard: 24°C)
+
+**So funktioniert es:**
+- Im Heizmodus: System arbeitet nur wenn Außentemperatur < Schwellenwert
+- Im Kühlmodus: System arbeitet nur wenn Außentemperatur > Schwellenwert  
+- Hat Vorrang vor allen anderen Einstellungen (Perioden, Boost, Abwesenheit)
+- Bei fehlenden Wetterdaten arbeitet das System normal als Fallback
 
 ## Verwendung
 

--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -26,5 +26,9 @@
     "BoostIntervall": "Zeit bis zum Ende des Boosts in Minuten",
     "StartStopDifference": "Differenz zur Solltemperatur bis zum Beginn oder Ende des Aufheizens",
     "ResetTemperaturesOnAdapterStart": "Zurücksetzen der Temperaturen auf die Standardwerte beim Start des Adapters",
-    "ResetTemperaturesOnStart": "Zurücksetzen der Temperaturen auf die Standardwerte beim Start des Adapters"
+    "ResetTemperaturesOnStart": "Zurücksetzen der Temperaturen auf die Standardwerte beim Start des Adapters",
+    "EnableWeatherControl": "Wetterbasierte Steuerung aktivieren",
+    "WeatherStatePath": "Wetter-Datenpunkt (Außentemperatur)",
+    "HeatingOutsideTemperatureThreshold": "Heizung: nur aktivieren wenn Außentemperatur unter (°C)",
+    "CoolingOutsideTemperatureThreshold": "Kühlung: nur aktivieren wenn Außentemperatur über (°C)"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -23,5 +23,9 @@
     "PauseIntervall": "Time until pause will be end in minutes",
     "BoostIntervall": "Time until boost will be end in minutes",
     "StartStopDifference": "Diffenernce from target temperature until start or stop heating",
-    "ResetTemperaturesOnStart": "Reset temperatures to default on adapter starts"
+    "ResetTemperaturesOnStart": "Reset temperatures to default on adapter starts",
+    "EnableWeatherControl": "Enable weather-based control",
+    "WeatherStatePath": "Weather state path (outside temperature)",
+    "HeatingOutsideTemperatureThreshold": "Heating: activate only if outside temperature below (°C)",
+    "CoolingOutsideTemperatureThreshold": "Cooling: activate only if outside temperature above (°C)"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -91,6 +91,49 @@
 					"md": 6,
 					"lg": 4,
 					"xl": 4
+				},
+				"enableWeatherControl": {
+					"type": "checkbox",
+					"label": "EnableWeatherControl",
+					"xs": 12,
+					"sm": 12,
+					"md": 6,
+					"lg": 4,
+					"xl": 4,
+					"default": false
+				},
+				"weatherStatePath": {
+					"type": "selectSendTo",
+					"label": "WeatherStatePath",
+					"command": "listStates",
+					"xs": 12,
+					"sm": 12,
+					"md": 8,
+					"lg": 8,
+					"xl": 8,
+					"hidden": "!data.enableWeatherControl"
+				},
+				"heatingOutsideTemperatureThreshold": {
+					"type": "number",
+					"label": "HeatingOutsideTemperatureThreshold",
+					"xs": 12,
+					"sm": 12,
+					"md": 6,
+					"lg": 4,
+					"xl": 4,
+					"default": 15,
+					"hidden": "!data.enableWeatherControl"
+				},
+				"coolingOutsideTemperatureThreshold": {
+					"type": "number",
+					"label": "CoolingOutsideTemperatureThreshold",
+					"xs": 12,
+					"sm": 12,
+					"md": 6,
+					"lg": 4,
+					"xl": 4,
+					"default": 24,
+					"hidden": "!data.enableWeatherControl"
 				}
 			}
 		},

--- a/io-package.json
+++ b/io-package.json
@@ -3,19 +3,6 @@
     "name": "heizungssteuerung",
     "version": "2.0.3",
     "news": {
-      "2.1.0": {
-        "en": "add weather-based heating/cooling control\nrefactor business logic into service classes\nadd comprehensive unit tests (91 tests)\nupdate dependencies to latest versions",
-        "de": "wetterbasierte Heiz-/Kühlsteuerung hinzugefügt\nGeschäftslogik in Service-Klassen refactored\numfassende Unit-Tests hinzugefügt (91 Tests)\nAbhängigkeiten auf neueste Versionen aktualisiert",
-        "ru": "добавить управление отоплением/охлаждением на основе погоды\nрефакторинг бизнес-логики в сервисные классы\nдобавить всесторонние модульные тесты (91 тест)\nобновить зависимости до последних версий",
-        "pt": "adicionar controle de aquecimento/resfriamento baseado no clima\nrefatorar lógica de negócios em classes de serviço\nadicionar testes unitários abrangentes (91 testes)\natualizar dependências para as versões mais recentes",
-        "nl": "weerbased verwarmings-/koelingscontrole toevoegen\nbedrijfslogica refactoren in serviceklassen\nomvattende unit tests toevoegen (91 tests)\nafhankelijkheden bijwerken naar nieuwste versies",
-        "fr": "ajouter le contrôle de chauffage/refroidissement basé sur la météo\nrefactoriser la logique métier dans les classes de service\najouter des tests unitaires complets (91 tests)\nmettre à jour les dépendances vers les dernières versions",
-        "it": "aggiungere controllo riscaldamento/raffreddamento basato sul tempo\nrefactoring logica aziendale in classi di servizio\naggiungere test unitari completi (91 test)\naggiornare dipendenze alle versioni più recenti",
-        "es": "agregar control de calefacción/refrigeración basado en el clima\nrefactorizar lógica de negocio en clases de servicio\nagregar pruebas unitarias integrales (91 pruebas)\nactualizar dependencias a las versiones más recientes",
-        "pl": "dodać kontrolę ogrzewania/chłodzenia opartą na pogodzie\nrefaktoryzacja logiki biznesowej w klasach usług\ndodać kompleksowe testy jednostkowe (91 testów)\nzaktualizować zależności do najnowszych wersji",
-        "uk": "додати управління опаленням/охолодженням на основі погоди\nрефакторинг бізнес-логіки в сервісні класи\nдодати всебічні модульні тести (91 тест)\nоновити залежності до останніх версій",
-        "zh-cn": "添加基于天气的供暖/制冷控制\n将业务逻辑重构为服务类\n添加全面的单元测试（91个测试）\n将依赖项更新到最新版本"
-      },
       "2.0.3": {
         "en": "fix absence format issue\nfix period matching issue",
         "de": "problem mit dem fehlenden format\nfixzeitanpassung problem",

--- a/io-package.json
+++ b/io-package.json
@@ -3,6 +3,19 @@
     "name": "heizungssteuerung",
     "version": "2.0.3",
     "news": {
+      "2.1.0": {
+        "en": "add weather-based heating/cooling control\nrefactor business logic into service classes\nadd comprehensive unit tests (91 tests)\nupdate dependencies to latest versions",
+        "de": "wetterbasierte Heiz-/Kühlsteuerung hinzugefügt\nGeschäftslogik in Service-Klassen refactored\numfassende Unit-Tests hinzugefügt (91 Tests)\nAbhängigkeiten auf neueste Versionen aktualisiert",
+        "ru": "добавить управление отоплением/охлаждением на основе погоды\nрефакторинг бизнес-логики в сервисные классы\nдобавить всесторонние модульные тесты (91 тест)\nобновить зависимости до последних версий",
+        "pt": "adicionar controle de aquecimento/resfriamento baseado no clima\nrefatorar lógica de negócios em classes de serviço\nadicionar testes unitários abrangentes (91 testes)\natualizar dependências para as versões mais recentes",
+        "nl": "weerbased verwarmings-/koelingscontrole toevoegen\nbedrijfslogica refactoren in serviceklassen\nomvattende unit tests toevoegen (91 tests)\nafhankelijkheden bijwerken naar nieuwste versies",
+        "fr": "ajouter le contrôle de chauffage/refroidissement basé sur la météo\nrefactoriser la logique métier dans les classes de service\najouter des tests unitaires complets (91 tests)\nmettre à jour les dépendances vers les dernières versions",
+        "it": "aggiungere controllo riscaldamento/raffreddamento basato sul tempo\nrefactoring logica aziendale in classi di servizio\naggiungere test unitari completi (91 test)\naggiornare dipendenze alle versioni più recenti",
+        "es": "agregar control de calefacción/refrigeración basado en el clima\nrefactorizar lógica de negocio en clases de servicio\nagregar pruebas unitarias integrales (91 pruebas)\nactualizar dependencias a las versiones más recientes",
+        "pl": "dodać kontrolę ogrzewania/chłodzenia opartą na pogodzie\nrefaktoryzacja logiki biznesowej w klasach usług\ndodać kompleksowe testy jednostkowe (91 testów)\nzaktualizować zależności do najnowszych wersji",
+        "uk": "додати управління опаленням/охолодженням на основі погоди\nрефакторинг бізнес-логіки в сервісні класи\nдодати всебічні модульні тести (91 тест)\nоновити залежності до останніх версій",
+        "zh-cn": "添加基于天气的供暖/制冷控制\n将业务逻辑重构为服务类\n添加全面的单元测试（91个测试）\n将依赖项更新到最新版本"
+      },
       "2.0.3": {
         "en": "fix absence format issue\nfix period matching issue",
         "de": "problem mit dem fehlenden format\nfixzeitanpassung problem",
@@ -168,7 +181,11 @@
     "periods": [],
     "pauseIntervall": 30,
     "boostIntervall": 30,
-    "startStopDifference": 0.5
+    "startStopDifference": 0.5,
+    "enableWeatherControl": false,
+    "weatherStatePath": "",
+    "heatingOutsideTemperatureThreshold": 15,
+    "coolingOutsideTemperatureThreshold": 24
   },
   "objects": [],
   "instanceObjects": []

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,8 @@ import { TimeUtils } from "./services/TimeUtils";
 import { TemperatureController, type TemperatureControllerConfig } from "./services/TemperatureController";
 import { PeriodService } from "./services/PeriodService";
 import { RoomManager } from "./services/RoomManager";
+import { WeatherService } from "./services/WeatherService";
+import { WeatherBasedController, type WeatherBasedControllerConfig } from "./services/WeatherBasedController";
 
 class Heizungssteuerung extends utils.Adapter {
 	roomNames: string[];
@@ -23,6 +25,8 @@ class Heizungssteuerung extends utils.Adapter {
 	roomManager!: RoomManager;
 	temperatureController!: TemperatureController;
 	periodService!: PeriodService;
+	weatherService!: WeatherService;
+	weatherBasedController!: WeatherBasedController;
 
 	public constructor(options: Partial<utils.AdapterOptions> = {}) {
 		super({
@@ -56,6 +60,16 @@ class Heizungssteuerung extends utils.Adapter {
 			this.config.isHeatingMode,
 		);
 
+		this.weatherService = new WeatherService(this);
+		const weatherControllerConfig: WeatherBasedControllerConfig = {
+			enableWeatherControl: this.config.enableWeatherControl || false,
+			weatherStatePath: this.config.weatherStatePath || "",
+			isHeatingMode: this.config.isHeatingMode,
+			heatingOutsideTemperatureThreshold: this.config.heatingOutsideTemperatureThreshold || 15,
+			coolingOutsideTemperatureThreshold: this.config.coolingOutsideTemperatureThreshold || 24,
+		};
+		this.weatherBasedController = new WeatherBasedController(weatherControllerConfig);
+
 		this.tempSensorMap = await this.buildFunctionToRoomMap("enum.functions.temperature", "Temperature");
 		this.humSensorMap = await this.buildFunctionToRoomMap("enum.functions.humidity", "Humidity");
 		this.engineMap = await this.buildFunctionToRoomMap("enum.functions.engine", "Engine");
@@ -79,6 +93,36 @@ class Heizungssteuerung extends utils.Adapter {
 		const now = TimeUtils.getCurrentTimeString();
 		const nowAsDate = TimeUtils.getCurrentDateTimeString();
 		this.log.debug(`current time is ${now}`);
+
+		//-------------------------------------------------
+		// check weather conditions
+		//-------------------------------------------------
+		let outsideTemperature: number | null = null;
+		if (this.weatherBasedController && this.config.enableWeatherControl) {
+			outsideTemperature = await this.weatherService.getOutsideTemperature(this.config.weatherStatePath);
+			const weatherAllowed = this.weatherBasedController.shouldAllowOperation(outsideTemperature);
+
+			if (weatherAllowed === false) {
+				this.log.info(
+					`Weather control: Operation blocked. Outside temp: ${outsideTemperature}°C, ` +
+						`${this.weatherBasedController.getControlDescription()}`,
+				);
+				// Deactivate all engines due to weather conditions
+				for (const roomName of this.roomNames) {
+					const engineId = this.engineMap.get(roomName);
+					if (engineId) {
+						await this.setForeignStateAsync(engineId, false);
+					}
+				}
+				return; // Skip all other heating/cooling logic
+			} else if (weatherAllowed === true) {
+				this.log.debug(
+					`Weather control: Operation allowed. Outside temp: ${outsideTemperature}°C, ` +
+						`${this.weatherBasedController.getControlDescription()}`,
+				);
+			}
+		}
+
 		const boostedRooms = await this.buildSpecialRoomsList("boost", this.config.boostIntervall);
 		const pausedRooms = await this.buildSpecialRoomsList("pause", this.config.pauseIntervall);
 		const roomTempMap = await this.buildDefaultRoomTempMap(now);

--- a/src/services/WeatherBasedController.test.ts
+++ b/src/services/WeatherBasedController.test.ts
@@ -1,0 +1,166 @@
+import { expect } from "chai";
+import { WeatherBasedController, type WeatherBasedControllerConfig } from "./WeatherBasedController";
+
+describe("WeatherBasedController", () => {
+	describe("Heating Mode", () => {
+		let controller: WeatherBasedController;
+
+		beforeEach(() => {
+			const config: WeatherBasedControllerConfig = {
+				enableWeatherControl: true,
+				weatherStatePath: "weather.temperature",
+				isHeatingMode: 0,
+				heatingOutsideTemperatureThreshold: 15,
+				coolingOutsideTemperatureThreshold: 24,
+			};
+			controller = new WeatherBasedController(config);
+		});
+
+		describe("shouldAllowOperation", () => {
+			it("should allow heating when outside temperature is below threshold", () => {
+				const result = controller.shouldAllowOperation(10);
+				expect(result).to.be.true;
+			});
+
+			it("should block heating when outside temperature is above threshold", () => {
+				const result = controller.shouldAllowOperation(20);
+				expect(result).to.be.false;
+			});
+
+			it("should block heating when outside temperature equals threshold", () => {
+				const result = controller.shouldAllowOperation(15);
+				expect(result).to.be.false;
+			});
+
+			it("should allow operation when temperature is null", () => {
+				const result = controller.shouldAllowOperation(null);
+				expect(result).to.be.true;
+			});
+		});
+
+		describe("getCurrentThreshold", () => {
+			it("should return heating threshold for heating mode", () => {
+				const result = controller.getCurrentThreshold();
+				expect(result).to.equal(15);
+			});
+		});
+
+		describe("getControlDescription", () => {
+			it("should return correct description for heating mode", () => {
+				const result = controller.getControlDescription();
+				expect(result).to.equal("Heating only allowed if outside temperature below 15°C");
+			});
+		});
+	});
+
+	describe("Cooling Mode", () => {
+		let controller: WeatherBasedController;
+
+		beforeEach(() => {
+			const config: WeatherBasedControllerConfig = {
+				enableWeatherControl: true,
+				weatherStatePath: "weather.temperature",
+				isHeatingMode: 1,
+				heatingOutsideTemperatureThreshold: 15,
+				coolingOutsideTemperatureThreshold: 24,
+			};
+			controller = new WeatherBasedController(config);
+		});
+
+		describe("shouldAllowOperation", () => {
+			it("should allow cooling when outside temperature is above threshold", () => {
+				const result = controller.shouldAllowOperation(30);
+				expect(result).to.be.true;
+			});
+
+			it("should block cooling when outside temperature is below threshold", () => {
+				const result = controller.shouldAllowOperation(20);
+				expect(result).to.be.false;
+			});
+
+			it("should block cooling when outside temperature equals threshold", () => {
+				const result = controller.shouldAllowOperation(24);
+				expect(result).to.be.false;
+			});
+
+			it("should allow operation when temperature is null", () => {
+				const result = controller.shouldAllowOperation(null);
+				expect(result).to.be.true;
+			});
+		});
+
+		describe("getCurrentThreshold", () => {
+			it("should return cooling threshold for cooling mode", () => {
+				const result = controller.getCurrentThreshold();
+				expect(result).to.equal(24);
+			});
+		});
+
+		describe("getControlDescription", () => {
+			it("should return correct description for cooling mode", () => {
+				const result = controller.getControlDescription();
+				expect(result).to.equal("Cooling only allowed if outside temperature above 24°C");
+			});
+		});
+	});
+
+	describe("Weather Control Disabled", () => {
+		let controller: WeatherBasedController;
+
+		beforeEach(() => {
+			const config: WeatherBasedControllerConfig = {
+				enableWeatherControl: false,
+				weatherStatePath: "weather.temperature",
+				isHeatingMode: 0,
+				heatingOutsideTemperatureThreshold: 15,
+				coolingOutsideTemperatureThreshold: 24,
+			};
+			controller = new WeatherBasedController(config);
+		});
+
+		describe("shouldAllowOperation", () => {
+			it("should return null when weather control is disabled", () => {
+				const result = controller.shouldAllowOperation(10);
+				expect(result).to.be.null;
+			});
+		});
+
+		describe("getControlDescription", () => {
+			it("should return disabled description", () => {
+				const result = controller.getControlDescription();
+				expect(result).to.equal("Weather control disabled");
+			});
+		});
+	});
+
+	describe("updateConfig", () => {
+		let controller: WeatherBasedController;
+
+		beforeEach(() => {
+			const config: WeatherBasedControllerConfig = {
+				enableWeatherControl: true,
+				weatherStatePath: "weather.temperature",
+				isHeatingMode: 0,
+				heatingOutsideTemperatureThreshold: 15,
+				coolingOutsideTemperatureThreshold: 24,
+			};
+			controller = new WeatherBasedController(config);
+		});
+
+		it("should update configuration correctly", () => {
+			const newConfig: WeatherBasedControllerConfig = {
+				enableWeatherControl: false,
+				weatherStatePath: "new.weather.path",
+				isHeatingMode: 1,
+				heatingOutsideTemperatureThreshold: 10,
+				coolingOutsideTemperatureThreshold: 30,
+			};
+
+			controller.updateConfig(newConfig);
+
+			expect(controller.shouldAllowOperation(20)).to.be.null;
+			expect(controller.getCurrentThreshold()).to.equal(30);
+			expect(controller.getControlDescription()).to.equal("Weather control disabled");
+		});
+	});
+});

--- a/src/services/WeatherBasedController.ts
+++ b/src/services/WeatherBasedController.ts
@@ -1,0 +1,88 @@
+/**
+ * Configuration interface for WeatherBasedController
+ */
+export interface WeatherBasedControllerConfig {
+	/** Enable weather-based control */
+	enableWeatherControl: boolean;
+	/** Path to weather state containing outside temperature */
+	weatherStatePath: string;
+	/** Heating mode: 0 = heating, 1 = cooling */
+	isHeatingMode: number;
+	/** Temperature threshold for heating mode (activate only if outside temp below this) */
+	heatingOutsideTemperatureThreshold: number;
+	/** Temperature threshold for cooling mode (activate only if outside temp above this) */
+	coolingOutsideTemperatureThreshold: number;
+}
+
+/**
+ * Controller for weather-based heating/cooling activation logic
+ */
+export class WeatherBasedController {
+	/**
+	 * Create new WeatherBasedController
+	 *
+	 * @param config Configuration object
+	 */
+	constructor(private config: WeatherBasedControllerConfig) {}
+
+	/**
+	 * Determine if heating/cooling should be allowed based on outside temperature
+	 *
+	 * @param outsideTemperature Current outside temperature
+	 * @returns True if heating/cooling should be allowed, false if blocked, null if weather control disabled
+	 */
+	shouldAllowOperation(outsideTemperature: number | null): boolean | null {
+		if (!this.config.enableWeatherControl) {
+			return null; // Weather control disabled, no restriction
+		}
+
+		if (outsideTemperature === null) {
+			// No weather data available - allow operation to prevent system failure
+			return true;
+		}
+
+		if (this.config.isHeatingMode === 0) {
+			// Heating mode: only activate if outside temperature is below threshold
+			return outsideTemperature < this.config.heatingOutsideTemperatureThreshold;
+		}
+		// Cooling mode: only activate if outside temperature is above threshold
+		return outsideTemperature > this.config.coolingOutsideTemperatureThreshold;
+	}
+
+	/**
+	 * Get current temperature threshold based on heating/cooling mode
+	 *
+	 * @returns Current temperature threshold
+	 */
+	getCurrentThreshold(): number {
+		return this.config.isHeatingMode === 0
+			? this.config.heatingOutsideTemperatureThreshold
+			: this.config.coolingOutsideTemperatureThreshold;
+	}
+
+	/**
+	 * Get description of current weather control rule
+	 *
+	 * @returns Human-readable description of the current rule
+	 */
+	getControlDescription(): string {
+		if (!this.config.enableWeatherControl) {
+			return "Weather control disabled";
+		}
+
+		const mode = this.config.isHeatingMode === 0 ? "Heating" : "Cooling";
+		const threshold = this.getCurrentThreshold();
+		const operator = this.config.isHeatingMode === 0 ? "below" : "above";
+
+		return `${mode} only allowed if outside temperature ${operator} ${threshold}°C`;
+	}
+
+	/**
+	 * Update configuration
+	 *
+	 * @param newConfig New configuration object
+	 */
+	updateConfig(newConfig: WeatherBasedControllerConfig): void {
+		this.config = newConfig;
+	}
+}

--- a/src/services/WeatherService.test.ts
+++ b/src/services/WeatherService.test.ts
@@ -1,0 +1,83 @@
+import { expect } from "chai";
+import { WeatherService } from "./WeatherService";
+import type * as utils from "@iobroker/adapter-core";
+
+// Mock adapter for testing
+class MockAdapter {
+	log = {
+		debug: () => {},
+		warn: () => {},
+		error: () => {},
+	};
+
+	getForeignStateAsync(id: string) {
+		// Mock implementation based on test scenarios
+		if (id === "weather.valid.temperature") {
+			return { val: 22.5, ts: Date.now() };
+		}
+		if (id === "weather.invalid.temperature") {
+			return { val: "invalid", ts: Date.now() };
+		}
+		if (id === "weather.null.temperature") {
+			return { val: null, ts: Date.now() };
+		}
+		if (id === "weather.nonexistent") {
+			return null;
+		}
+		return null;
+	}
+}
+
+describe("WeatherService", () => {
+	let weatherService: WeatherService;
+	let mockAdapter: MockAdapter;
+
+	beforeEach(() => {
+		mockAdapter = new MockAdapter();
+		weatherService = new WeatherService(mockAdapter as unknown as utils.AdapterInstance);
+	});
+
+	describe("getOutsideTemperature", () => {
+		it("should return temperature for valid weather state", async () => {
+			const result = await weatherService.getOutsideTemperature("weather.valid.temperature");
+			expect(result).to.equal(22.5);
+		});
+
+		it("should return null for invalid temperature value", async () => {
+			const result = await weatherService.getOutsideTemperature("weather.invalid.temperature");
+			expect(result).to.be.null;
+		});
+
+		it("should return null for null temperature value", async () => {
+			const result = await weatherService.getOutsideTemperature("weather.null.temperature");
+			expect(result).to.be.null;
+		});
+
+		it("should return null for nonexistent weather state", async () => {
+			const result = await weatherService.getOutsideTemperature("weather.nonexistent");
+			expect(result).to.be.null;
+		});
+
+		it("should return null for empty weather state path", async () => {
+			const result = await weatherService.getOutsideTemperature("");
+			expect(result).to.be.null;
+		});
+	});
+
+	describe("isWeatherStateValid", () => {
+		it("should return true for existing weather state", async () => {
+			const result = await weatherService.isWeatherStateValid("weather.valid.temperature");
+			expect(result).to.be.true;
+		});
+
+		it("should return false for nonexistent weather state", async () => {
+			const result = await weatherService.isWeatherStateValid("weather.nonexistent");
+			expect(result).to.be.false;
+		});
+
+		it("should return false for empty weather state path", async () => {
+			const result = await weatherService.isWeatherStateValid("");
+			expect(result).to.be.false;
+		});
+	});
+});

--- a/src/services/WeatherService.ts
+++ b/src/services/WeatherService.ts
@@ -1,0 +1,68 @@
+import type * as utils from "@iobroker/adapter-core";
+
+/**
+ * Service for retrieving weather data from ioBroker states
+ */
+export class WeatherService {
+	/**
+	 * Create new WeatherService
+	 *
+	 * @param adapter The ioBroker adapter instance
+	 */
+	constructor(private adapter: utils.AdapterInstance) {}
+
+	/**
+	 * Get current outside temperature from configured weather state
+	 *
+	 * @param weatherStatePath Path to weather temperature state
+	 * @returns Current outside temperature or null if unavailable
+	 */
+	async getOutsideTemperature(weatherStatePath: string): Promise<number | null> {
+		if (!weatherStatePath) {
+			this.adapter.log.debug("No weather state path configured");
+			return null;
+		}
+
+		try {
+			const weatherState = await this.adapter.getForeignStateAsync(weatherStatePath);
+			if (!weatherState || weatherState.val === null || weatherState.val === undefined) {
+				this.adapter.log.warn(`Weather state ${weatherStatePath} is not available or has no value`);
+				return null;
+			}
+
+			const temperature = Number(weatherState.val);
+			if (isNaN(temperature)) {
+				this.adapter.log.warn(
+					`Weather state ${weatherStatePath} contains invalid temperature value: ${weatherState.val}`,
+				);
+				return null;
+			}
+
+			this.adapter.log.debug(`Current outside temperature: ${temperature}°C`);
+			return temperature;
+		} catch (error) {
+			this.adapter.log.error(`Error reading weather state ${weatherStatePath}: ${String(error)}`);
+			return null;
+		}
+	}
+
+	/**
+	 * Check if weather state path is valid and accessible
+	 *
+	 * @param weatherStatePath Path to weather temperature state
+	 * @returns True if state exists and is readable
+	 */
+	async isWeatherStateValid(weatherStatePath: string): Promise<boolean> {
+		if (!weatherStatePath) {
+			return false;
+		}
+
+		try {
+			const weatherState = await this.adapter.getForeignStateAsync(weatherStatePath);
+			return weatherState !== null && weatherState !== undefined;
+		} catch (error) {
+			this.adapter.log.error(`Error validating weather state ${weatherStatePath}: ${String(error)}`);
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
New Features:
- Weather-based control: activate/deactivate based on outside temperature
- Configurable temperature thresholds (default: 15°C heating, 24°C cooling)
- Optional feature with selectable weather data source
- Priority: Weather > Pause > Boost > Absence > Periods

Technical Improvements:
- Add WeatherService for weather data integration
- Add WeatherBasedController for intelligent control logic
- Extend admin interface with weather control settings
- Add comprehensive unit tests (23 new tests, 91 total)
- Complete German and English translations
- Clean TypeScript implementation without any-types

Configuration:
- enableWeatherControl: activate weather-based control
- weatherStatePath: selectable state containing outside temperature
- heatingOutsideTemperatureThreshold: heating only below this temp
- coolingOutsideTemperatureThreshold: cooling only above this temp

🤖 Generated with [Claude Code](https://claude.ai/code)