### PR TITLE
fix: replace invalid state roles with correct ioBroker roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ Enable debug logging in adapter settings to see detailed information about:
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (jbeenenga) fix invalid state roles according to ioBroker documentation
+
 ### 2.1.1 (2025-09-02)
  - (jbeenenga) correct outsite temperature path setting
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -347,7 +347,7 @@ class Heizungssteuerung extends utils.Adapter {
 					name: "Activate boost for this room",
 					read: true,
 					write: true,
-					role: "state",
+					role: "switch",
 					def: false,
 				},
 			});
@@ -360,7 +360,7 @@ class Heizungssteuerung extends utils.Adapter {
 					name: "Activate pause for this room",
 					read: true,
 					write: true,
-					role: "state",
+					role: "switch",
 					def: false,
 				},
 			});
@@ -374,10 +374,10 @@ class Heizungssteuerung extends utils.Adapter {
 			native: {},
 			common: {
 				type: "boolean",
-				name: "Activate boost for any room",
+				name: "Activate pause for any room",
 				read: true,
 				write: true,
-				role: "state",
+				role: "switch",
 				def: false,
 			},
 		});
@@ -390,7 +390,7 @@ class Heizungssteuerung extends utils.Adapter {
 				name: "Activate boost for any room",
 				read: true,
 				write: true,
-				role: "state",
+				role: "switch",
 				def: false,
 			},
 		});
@@ -404,7 +404,7 @@ class Heizungssteuerung extends utils.Adapter {
 				name: "Date and time until absence mode should be active (Format-Examlpe: \"01.01.2025, 15:30\")",
 				read: true,
 				write: true,
-				role: "state",
+				role: "date",
 				def: "01.01.2025, 15:30",
 			},
 		});
@@ -438,25 +438,37 @@ class Heizungssteuerung extends utils.Adapter {
 				type: "state",
 				_id: `Temperatures.${room}.current`,
 				native: {},
-				common: { type: "number", name: "Current temperature", read: true, write: false, role: "state" },
+				common: {
+					type: "number",
+					name: "Current temperature",
+					read: true,
+					write: false,
+					role: "value.temperature",
+				},
 			});
 			void this.setObjectNotExists(`Temperatures.${room}.currentHumidity`, {
 				type: "state",
 				_id: `Temperatures.${room}.currentHumidity`,
 				native: {},
-				common: { type: "number", name: "Current humidity", read: true, write: false, role: "state" },
+				common: { type: "number", name: "Current humidity", read: true, write: false, role: "value.humidity" },
 			});
 			void this.setObjectNotExists(`Temperatures.${room}.target`, {
 				type: "state",
 				_id: `Temperatures.${room}.target`,
 				native: {},
-				common: { type: "number", name: "Target temperature", read: true, write: true, role: "state" },
+				common: {
+					type: "number",
+					name: "Target temperature",
+					read: true,
+					write: true,
+					role: "level.temperature",
+				},
 			});
 			void this.setObjectNotExists(`Temperatures.${room}.targetUntil`, {
 				type: "state",
 				_id: `Temperatures.${room}.target`,
 				native: {},
-				common: { type: "string", name: "Target temperature until", read: true, write: true, role: "state" },
+				common: { type: "string", name: "Target temperature until", read: true, write: true, role: "date" },
 			});
 		});
 		this.roomNames.forEach(room => {


### PR DESCRIPTION
- Replace generic "state" role with semantic roles:
  - Boolean action states (boost/pause): "state" → "switch"
  - Current temperature: "state" → "value.temperature"
  - Current humidity: "state" → "value.humidity"
  - Target temperature: "state" → "level.temperature"
  - Date/time fields: "state" → "date"
- Fix incorrect name for pauseAll action
- Align roles with official ioBroker documentation

Fixes #146

🤖 Generated with [Claude Code](https://claude.ai/code)